### PR TITLE
Readmeのアップデート（env利用を含む）

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,7 @@ ClaudeなどのAIアシスタントがmicroCMSのコンテンツ管理システ�
 
 ## セットアップ
 
-### Claude Desktop
-
-#### 方法1: MCP Bundle (旧DXTファイル) を使う
+### 方法1: MCP Bundle (旧DXTファイル) を使う
 
 Claude Desktopに導入する場合、mcpbファイルを使って簡単にインストールできます。
 
@@ -19,9 +17,7 @@ Claude Desktopに導入する場合、mcpbファイルを使って簡単にイ�
 2. ダウンロードしたmcpbファイルをダブルクリックで開く
 3. サービスIDとAPIキーを設定する
 
-#### 方法2: npx をつかう
-
-`claude_desktop_config.json` ファイルに以下を追加します。詳細については、Claude Desktop [ドキュメンテーション](https://modelcontextprotocol.io/docs/develop/connect-local-servers)を参照してください。
+### 方法2: npx をつかう
 
 ```json
 {
@@ -40,7 +36,7 @@ Claude Desktopに導入する場合、mcpbファイルを使って簡単にイ�
 
 `<MICROCMS_SERVICE_ID>`, `<MICROCMS_API_KEY>` はご自身のものに置き換えてください。
 
-設定更新後、Claude Desktopを再起動してください。
+設定更新後はクライアントを再起動してください。
 
 ## 利用方法
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ microCMSのメディア一覧に画像をアップロードする
 
 以下の記事でより詳しい使い方を紹介しています。
 
-- [microCMSのMCPサーバーをリリースしました](https://blog.microcms.io/microcms-mcp-server/)
+- [microCMSのMCPサーバーをリリースしました | microCMSブログ](https://blog.microcms.io/microcms-mcp-server/)
 - [MCPサーバーからmicroCMSにコンテンツを入稿する | Zenn](https://zenn.dev/himara2/articles/14eb2260c4f0e4)
 
 ## ライセンス

--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ ClaudeなどのAIアシスタントがmicroCMSのコンテンツ管理システ�
 
 ## セットアップ
 
-### 方法1: MCP Bundle (旧DXTファイル) を使う
+### Claude Desktop
+
+#### 方法1: MCP Bundle (旧DXTファイル) を使う
 
 Claude Desktopに導入する場合、mcpbファイルを使って簡単にインストールできます。
 
@@ -17,57 +19,59 @@ Claude Desktopに導入する場合、mcpbファイルを使って簡単にイ�
 2. ダウンロードしたmcpbファイルをダブルクリックで開く
 3. サービスIDとAPIキーを設定する
 
+#### 方法2: npx をつかう
 
-### 方法2: npx をつかう
+`claude_desktop_config.json` ファイルに以下を追加します。詳細については、Claude Desktop [ドキュメンテーション](https://modelcontextprotocol.io/docs/develop/connect-local-servers)を参照してください。
 
 ```json
 {
   "mcpServers": {
     "microcms": {
       "command": "npx",
-      "args": [
-        "-y",
-        "microcms-mcp-server@latest",
-        "--service-id", "<MICROCMS_SERVICE_ID>",
-        "--api-key", "<MICROCMS_API_KEY>"
-      ]
+      "args": ["-y", "microcms-mcp-server@latest"],
+      "env": {
+        "MICROCMS_SERVICE_ID": "<MICROCMS_SERVICE_ID>",
+        "MICROCMS_API_KEY": "<MICROCMS_API_KEY>"
+      }
     }
   }
 }
 ```
 
-`MICROCMS_SERVICE_ID`, `MICROCMS_API_KEY` はご自身のものに置き換えてください。
+`<MICROCMS_SERVICE_ID>`, `<MICROCMS_API_KEY>` はご自身のものに置き換えてください。
 
 設定更新後、Claude Desktopを再起動してください。
 
 ## 利用方法
 
-### 1. 最初にmicroCMSのAPIスキーマを伝える
+### 1. 操作を行いたいmicroCMSのAPIのエンドポイントを伝える
 
 ```
-これはmicroCMSのAPIスキーマです。内容を理解してください
+microCMSのarticleに対して操作を行いたいです
 ```
-
-APIスキーマは [microCMSの管理画面 > API設定](https://document.microcms.io/manual/export-and-import-api-schema) からJSON形式でエクスポートできます。
 
 ### 2. microCMSからコンテンツを取得・入稿します
 
 microCMSのコンテンツを確認する
+
 ```
 microCMSの news から最新の記事を10件取得してください
 ```
 
 microCMSにコンテンツを作成して入稿する
+
 ```
 MCPサーバーの概要や利用例について調べ、それを1000文字程度でまとめてmicroCMSの blogs に入稿してください
 ```
 
 microCMSのコンテンツを取得してレビューしてもらう
+
 ```
 microCMSの xxxxxx のコンテンツを取得して、日本語的におかしい部分があれば指摘して
 ```
 
 microCMSのメディア一覧に画像をアップロードする
+
 ```
 次の画像をmicroCMSにアップロードして。
 
@@ -78,8 +82,10 @@ microCMSのメディア一覧に画像をアップロードする
 
 ### より詳しい使い方
 
-こちらの記事でより詳しい使い方を紹介しています。  
-[MCPサーバーからmicroCMSにコンテンツを入稿する | Zenn](https://zenn.dev/himara2/articles/14eb2260c4f0e4)
+以下の記事でより詳しい使い方を紹介しています。
+
+- [microCMSのMCPサーバーをリリースしました](https://blog.microcms.io/microcms-mcp-server/)
+- [MCPサーバーからmicroCMSにコンテンツを入稿する | Zenn](https://zenn.dev/himara2/articles/14eb2260c4f0e4)
 
 ## ライセンス
 


### PR DESCRIPTION
- ローカルMCPサーバーの連携については、envを利用して情報を渡していることが多いようなので、そのように記載を変更しました。
https://docs.stripe.com/mcp?locale=ja-JP&mcp-client=claude
  - env渡しでも動作することは確認済みです。
  - Claude Desktopであれば、以下のように「詳細オプション」の中に値が隠れるようになります。
<img width="597" height="408" alt="CleanShot 2025-10-06 at 6  28 10" src="https://github.com/user-attachments/assets/468ed172-f1a6-4188-9cd9-91a14d317d9c" />

- その他情報のアップデート、微修正を行いました