### PR TITLE
ci: update GitHub Actions workflows to use SHA pinning versions of actions

### DIFF
--- a/.github/workflows/build-mcpb.yml
+++ b/.github/workflows/build-mcpb.yml
@@ -15,15 +15,15 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
     - name: Setup pnpm
-      uses: pnpm/action-setup@v4
+      uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
       with:
         version: 9
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version: '22'
         cache: 'pnpm'
@@ -61,7 +61,7 @@ jobs:
         ls -la *.mcpb
 
     - name: Upload MCPB as artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: microcms-mcp-server-mcpb
         path: |
@@ -75,7 +75,7 @@ jobs:
 
     steps:
     - name: Download MCPB artifact
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
       with:
         name: microcms-mcp-server-mcpb
 
@@ -83,7 +83,7 @@ jobs:
       run: ls -la
 
     - name: Create Release
-      uses: softprops/action-gh-release@v2
+      uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
       with:
         files: |
           microcms-mcp-server.mcpb

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,13 +13,13 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
         with:
           version: 9
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'


### PR DESCRIPTION
GitHub Actionsで利用しているActionsのバージョンをタグではなくコミットSHAを指定にしました。

※ 今回、バージョン上げはしていません。
