### PR TITLE
chore: add pnpm workspace configuration with minimum release age

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+# 単位: 分
+minimumReleaseAge: 7200


### PR DESCRIPTION
利用するライブラリがリリースされてから一定期間経ったものしかインストールできないようにする設定を加えました