### PR TITLE
コンテンツ予約ツールを追加

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -77,6 +77,10 @@
       "description": "Change content creator in microCMS (Management API). Updates the createdBy field of a content item to a specified member ID"
     },
     {
+      "name": "microcms_update_content_reservation",
+      "description": "Set or clear content publish and stop reservation schedules in microCMS (Management API)"
+    },
+    {
       "name": "microcms_delete_content",
       "description": "Delete content from microCMS"
     },

--- a/src/client.ts
+++ b/src/client.ts
@@ -549,6 +549,34 @@ export async function patchContentCreatedBy(
   return await response.json();
 }
 
+export async function updateContentReservation(
+  endpoint: string,
+  contentId: string,
+  reservation: { publishTime?: string; stopTime?: string },
+  serviceId?: string
+): Promise<{ id: string }> {
+  const clients = getClientsForService(serviceId);
+  const url = `https://${clients.serviceDomain}.microcms-management.io/api/v1/contents/${endpoint}/${contentId}/reservation`;
+
+  const response = await fetch(url, {
+    method: 'PUT',
+    headers: {
+      'X-MICROCMS-API-KEY': clients.apiKey,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(reservation),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(
+      `Failed to update content reservation: ${response.status} ${response.statusText} - ${errorText}`
+    );
+  }
+
+  return await response.json();
+}
+
 export async function getListMeta(
   endpoint: string,
   options?: { limit?: number; offset?: number },

--- a/src/server.ts
+++ b/src/server.ts
@@ -61,10 +61,14 @@ import {
   handleUpdateContentPublished,
   updateContentPublishedTool,
 } from './tools/update-content-published.js';
+import {
+  handleUpdateContentReservation,
+  updateContentReservationTool,
+} from './tools/update-content-reservation.js';
 import { handleUploadMedia, uploadMediaTool } from './tools/upload-media.js';
 import type { BulkToolParameters, ToolParameters } from './types.js';
 
-// Fixed tool list (21 tools)
+// Fixed tool list (22 tools)
 const tools = [
   getServicesTool,
   getListTool,
@@ -80,6 +84,7 @@ const tools = [
   patchContentTool,
   patchContentStatusTool,
   patchContentCreatedByTool,
+  updateContentReservationTool,
   deleteContentTool,
   getMediaTool,
   uploadMediaTool,
@@ -121,6 +126,7 @@ const toolHandlers: Record<
   microcms_patch_content: handlePatchContent,
   microcms_patch_content_status: handlePatchContentStatus,
   microcms_patch_content_created_by: handlePatchContentCreatedBy,
+  microcms_update_content_reservation: handleUpdateContentReservation,
   microcms_delete_content: handleDeleteContent,
   microcms_get_media: handleGetMedia,
   microcms_upload_media: handleUploadMedia,

--- a/src/tools/update-content-reservation.ts
+++ b/src/tools/update-content-reservation.ts
@@ -1,0 +1,84 @@
+import type { Tool } from '@modelcontextprotocol/sdk/types.js';
+import { updateContentReservation } from '../client.js';
+import type { ToolParameters } from '../types.js';
+
+export const updateContentReservationTool: Tool = {
+  name: 'microcms_update_content_reservation',
+  description:
+    'Set or clear content publish/stop reservation schedules in microCMS (Management API). Provide publishTime and/or stopTime as ISO 8601 strings. If neither is provided, existing publish and stop reservations are cleared.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      serviceId: {
+        type: 'string',
+        description:
+          'Service ID (required in multi-service mode, optional in single-service mode)',
+      },
+      endpoint: {
+        type: 'string',
+        description: 'Content type name (e.g., "blogs", "news")',
+      },
+      contentId: {
+        type: 'string',
+        description: 'Content ID to update reservation schedules',
+      },
+      publishTime: {
+        type: 'string',
+        description:
+          'Publish reservation time as an ISO 8601 string (e.g., "2026-01-14T15:31:24.668+09:00" or "2026-01-14T06:31:24.668Z"). Omit to clear any existing publish reservation.',
+      },
+      stopTime: {
+        type: 'string',
+        description:
+          'Stop reservation time as an ISO 8601 string (e.g., "2026-01-14T15:31:24.668+09:00" or "2026-01-14T06:31:24.668Z"). Omit to clear any existing stop reservation.',
+      },
+    },
+    required: ['endpoint', 'contentId'],
+  },
+};
+
+export async function handleUpdateContentReservation(
+  params: ToolParameters,
+  serviceId?: string
+) {
+  const { endpoint, contentId, publishTime, stopTime } = params;
+
+  if (!endpoint) {
+    throw new Error('endpoint is required');
+  }
+
+  if (!contentId) {
+    throw new Error('contentId is required');
+  }
+
+  if (publishTime === '' || stopTime === '') {
+    throw new Error('publishTime and stopTime must not be empty strings');
+  }
+
+  const reservation: { publishTime?: string; stopTime?: string } = {};
+  if (publishTime !== undefined) {
+    reservation.publishTime = publishTime;
+  }
+  if (stopTime !== undefined) {
+    reservation.stopTime = stopTime;
+  }
+
+  const result = await updateContentReservation(
+    endpoint,
+    contentId,
+    reservation,
+    serviceId
+  );
+
+  if (!publishTime && !stopTime) {
+    return {
+      message: `Content ${contentId} reservation schedules cleared`,
+      id: result.id,
+    };
+  }
+
+  return {
+    message: `Content ${contentId} reservation schedules updated`,
+    id: result.id,
+  };
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -132,6 +132,9 @@ export interface ToolParameters {
   status?: 'PUBLISH' | 'DRAFT';
   // CreatedBy parameters
   createdBy?: string;
+  // Reservation parameters
+  publishTime?: string;
+  stopTime?: string;
 }
 
 export interface MediaToolParameters {


### PR DESCRIPTION
## 概要

microCMS Management API のコンテンツ予約エンドポイントを利用する MCP ツールを追加しました。
SDK未反映のために、直接APIへリクエストする形式を採用しています。（他ツールで実績あり）
https://document.microcms.io/management-api/put-contents-reservation

## 変更内容

- `microcms_update_content_reservation` ツールを追加
- `publishTime` / `stopTime` による公開予約・停止予約の設定に対応
- `publishTime` と `stopTime` をどちらも省略した場合、既存の予約を解除するように `{}` を送信
- MCP サーバーのツール一覧と handler に登録
- `manifest.json` のツール一覧に追加

## 確認内容

- `pnpm exec biome check src/ manifest.json`
- `pnpm run build`
- 手動テスト済み
