### PR TITLE
MCPBビルドでhoistedな依存レイアウトを使う

### DIFF
--- a/.github/workflows/build-mcpb.yml
+++ b/.github/workflows/build-mcpb.yml
@@ -34,8 +34,10 @@ jobs:
     - name: Build project
       run: pnpm run build
 
-    - name: Install MCPB CLI globally
-      run: npm install -g @anthropic-ai/mcpb@1.1.1
+    - name: Prepare production dependencies for MCPB
+      run: |
+        rm -rf node_modules
+        pnpm install --prod --frozen-lockfile --config.node-linker=hoisted
 
     - name: Create MCPB package
       run: |
@@ -44,7 +46,7 @@ jobs:
         echo "Building MCPB for version: $VERSION"
 
         # Create MCPB directly in project root (mcpb pack includes dependencies)
-        npx @anthropic-ai/mcpb@1.1.1 pack
+        npx @anthropic-ai/mcpb@2.1.2 pack
 
         # Rename to include version
         mv microcms-mcp-server.mcpb microcms-mcp-server-v${VERSION}.mcpb


### PR DESCRIPTION
## 概要

MCPB生成時に、pnpm標準のsymlink layoutではなく、pack前だけproduction依存をhoisted layoutで入れ直すようにしました。あわせて、MCPB CLIを `@anthropic-ai/mcpb@2.1.2` に更新しています。

## 背景

ビルドしたMCP BundleをClaude Desktopに登録すると、`initialize` 送信後にサーバーtransportが閉じ、MCPサーバーが早期終了する状態になっていました。

ローカルで `dist/index.js` を直接起動すると問題なく動作しましたが、MCPBを展開したディレクトリから起動すると、以下のように `@modelcontextprotocol/sdk` の依存解決に失敗しました。

```text
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'ajv-formats'
imported from .../node_modules/@modelcontextprotocol/sdk/dist/esm/validation/ajv-provider.js
```

pnpm標準layoutでは依存の実体が `node_modules/.pnpm` 配下に置かれ、rootの `node_modules/*` はsymlinkになります。MCPB pack後に展開するとこの参照関係が崩れ、`.pnpm` 配下に依存は存在していても、Nodeの通常のmodule resolutionでは `ajv-formats` などを見つけられない状態になっていました。

## 変更内容

- MCPB pack前に `node_modules` を削除
- `pnpm install --prod --frozen-lockfile --config.node-linker=hoisted` でproduction依存をhoisted layoutとして再インストール
- `@anthropic-ai/mcpb` を `1.1.1` から `2.1.2` に更新
- グローバルinstallをやめ、`npx @anthropic-ai/mcpb@2.1.2 pack` を直接使うように変更

## 検証

一時ディレクトリで同等手順を実行し、生成したMCPBを展開したうえで、展開先の `dist/index.js` をSDKクライアントから起動しました。

```text
microCMS MCP Server starting in single-service mode (service: dummy)
connected
tools 21
```

また、通常pnpm layoutで生成したMCPBでは約70.7MBだったpackage sizeが、hoisted layoutでは約20.2MBまで小さくなることも確認しています。これは `.pnpm` 配下とroot側の依存が重複してpackされることを避けられるためです。
