### PR TITLE
[codex] manifest に get services ツールを追加

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -25,6 +25,10 @@
   },
   "tools": [
     {
+      "name": "microcms_get_services",
+      "description": "Get list of configured microCMS services and their available APIs (endpoints). Use this tool first to discover which services are available and find the correct serviceId for other tools."
+    },
+    {
       "name": "microcms_get_list",
       "description": "Get a list of content from microCMS with filtering and search capabilities"
     },


### PR DESCRIPTION
## 概要

`manifest.json` の `tools` に `microcms_get_services` を追加しました。

## 背景

サーバー本体の `ListTools` では `microcms_get_services` を含む 21 個のツールが登録されていますが、MCP Bundle 用の `manifest.json` では同ツールが宣言されていませんでした。

この差分により、MCPB やホスト側の事前表示・権限表示・設定 UI で、実際に利用できるツールより 1 個少なく見える可能性がありました。

## 変更内容

- `manifest.json` の `tools` 配列に `microcms_get_services` を追加
- サーバー本体のツール順に合わせて先頭へ配置

## 確認

- `manifest.json` を `JSON.parse` で検証
- `pnpm run build`
