### PR TITLE
MCPサーバーのメタデータバージョンを同期

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -144,7 +144,7 @@ export function createMcpServer(): Server {
   const server = new Server(
     {
       name: 'microcms-mcp-server',
-      version: '0.8.0',
+      version: '0.10.0',
     },
     {
       capabilities: {


### PR DESCRIPTION
## 概要

- MCPサーバーのメタデータバージョンを `package.json` / `manifest.json` と同じ `0.10.0` に更新しました
- MCPクライアント上で古いバージョンが表示される可能性を解消します

## 確認

- [x] pnpm run build