### PR TITLE
コンテンツ書き込み系レスポンスに管理画面URLを追加

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -10,6 +10,7 @@ import type {
   AppConfig,
   ContentMeta,
   ContentMetaListResponse,
+  ContentWriteResponse,
   MediaListResponse,
   MediaUploadResponse,
   MemberInfo,
@@ -34,6 +35,14 @@ interface ServiceClients {
 const clientMap = new Map<string, ServiceClients>();
 let appConfig: AppConfig | null = null;
 let defaultServiceId: string | null = null;
+
+function buildContentAdminUrl(
+  serviceDomain: string,
+  endpoint: string,
+  contentId: string
+): string {
+  return `https://${serviceDomain}.microcms.io/apis/${endpoint}/${contentId}`;
+}
 
 /**
  * Initialize clients based on configuration.
@@ -309,13 +318,17 @@ export async function create<T = MicroCMSContent>(
   >,
   options?: { isDraft?: boolean; contentId?: string },
   serviceId?: string
-): Promise<{ id: string }> {
+): Promise<ContentWriteResponse> {
   const clients = getClientsForService(serviceId);
-  return await clients.client.create({
+  const result = await clients.client.create({
     endpoint,
     content,
     ...options,
   });
+  return {
+    ...result,
+    adminUrl: buildContentAdminUrl(clients.serviceDomain, endpoint, result.id),
+  };
 }
 
 export async function update<T = MicroCMSContent>(
@@ -327,14 +340,18 @@ export async function update<T = MicroCMSContent>(
   >,
   options?: { isDraft?: boolean },
   serviceId?: string
-): Promise<{ id: string }> {
+): Promise<ContentWriteResponse> {
   const clients = getClientsForService(serviceId);
-  return await clients.client.update({
+  const result = await clients.client.update({
     endpoint,
     contentId,
     content,
     ...options,
   });
+  return {
+    ...result,
+    adminUrl: buildContentAdminUrl(clients.serviceDomain, endpoint, result.id),
+  };
 }
 
 export async function patch<T = MicroCMSContent>(
@@ -345,14 +362,18 @@ export async function patch<T = MicroCMSContent>(
   >,
   options?: { isDraft?: boolean },
   serviceId?: string
-): Promise<{ id: string }> {
+): Promise<ContentWriteResponse> {
   const clients = getClientsForService(serviceId);
-  return await clients.client.update({
+  const result = await clients.client.update({
     endpoint,
     contentId,
     content,
     ...options,
   });
+  return {
+    ...result,
+    adminUrl: buildContentAdminUrl(clients.serviceDomain, endpoint, result.id),
+  };
 }
 
 export async function deleteContent(
@@ -500,7 +521,7 @@ export async function patchContentStatus(
   contentId: string,
   status: 'PUBLISH' | 'DRAFT',
   serviceId?: string
-): Promise<void> {
+): Promise<ContentWriteResponse> {
   const clients = getClientsForService(serviceId);
   const url = `https://${clients.serviceDomain}.microcms-management.io/api/v1/contents/${endpoint}/${contentId}/status`;
 
@@ -519,6 +540,11 @@ export async function patchContentStatus(
       `Failed to patch content status: ${response.status} ${response.statusText} - ${errorText}`
     );
   }
+
+  return {
+    id: contentId,
+    adminUrl: buildContentAdminUrl(clients.serviceDomain, endpoint, contentId),
+  };
 }
 
 export async function patchContentCreatedBy(
@@ -526,7 +552,7 @@ export async function patchContentCreatedBy(
   contentId: string,
   memberId: string,
   serviceId?: string
-): Promise<{ id: string }> {
+): Promise<ContentWriteResponse> {
   const clients = getClientsForService(serviceId);
   const url = `https://${clients.serviceDomain}.microcms-management.io/api/v1/contents/${endpoint}/${contentId}/createdBy`;
 
@@ -546,7 +572,11 @@ export async function patchContentCreatedBy(
     );
   }
 
-  return await response.json();
+  const result = await response.json();
+  return {
+    ...result,
+    adminUrl: buildContentAdminUrl(clients.serviceDomain, endpoint, result.id),
+  };
 }
 
 export async function updateContentReservation(
@@ -554,7 +584,7 @@ export async function updateContentReservation(
   contentId: string,
   reservation: { publishTime?: string; stopTime?: string },
   serviceId?: string
-): Promise<{ id: string }> {
+): Promise<ContentWriteResponse> {
   const clients = getClientsForService(serviceId);
   const url = `https://${clients.serviceDomain}.microcms-management.io/api/v1/contents/${endpoint}/${contentId}/reservation`;
 
@@ -574,7 +604,11 @@ export async function updateContentReservation(
     );
   }
 
-  return await response.json();
+  const result = await response.json();
+  return {
+    ...result,
+    adminUrl: buildContentAdminUrl(clients.serviceDomain, endpoint, result.id),
+  };
 }
 
 export async function getListMeta(

--- a/src/tools/patch-content-created-by.ts
+++ b/src/tools/patch-content-created-by.ts
@@ -59,5 +59,6 @@ export async function handlePatchContentCreatedBy(
   return {
     message: `Content ${contentId} creator changed to ${createdBy}`,
     id: result.id,
+    adminUrl: result.adminUrl,
   };
 }

--- a/src/tools/patch-content-status.ts
+++ b/src/tools/patch-content-status.ts
@@ -51,6 +51,15 @@ export async function handlePatchContentStatus(
     throw new Error('status must be either "PUBLISH" or "DRAFT"');
   }
 
-  await patchContentStatus(endpoint, contentId, status, serviceId);
-  return { message: `Content ${contentId} status changed to ${status}` };
+  const result = await patchContentStatus(
+    endpoint,
+    contentId,
+    status,
+    serviceId
+  );
+  return {
+    message: `Content ${contentId} status changed to ${status}`,
+    id: result.id,
+    adminUrl: result.adminUrl,
+  };
 }

--- a/src/tools/update-content-reservation.ts
+++ b/src/tools/update-content-reservation.ts
@@ -74,11 +74,13 @@ export async function handleUpdateContentReservation(
     return {
       message: `Content ${contentId} reservation schedules cleared`,
       id: result.id,
+      adminUrl: result.adminUrl,
     };
   }
 
   return {
     message: `Content ${contentId} reservation schedules updated`,
     id: result.id,
+    adminUrl: result.adminUrl,
   };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -84,6 +84,11 @@ export interface MicroCMSContent {
   [key: string]: unknown;
 }
 
+export interface ContentWriteResponse {
+  id: string;
+  adminUrl: string;
+}
+
 export interface MicroCMSListResponse<T = MicroCMSContent> {
   contents: T[];
   totalCount: number;


### PR DESCRIPTION
## 概要

コンテンツの書き込み系ツールのレスポンスに、microCMS 管理画面で該当コンテンツを開ける URL を追加します。

形式は以下です。

```
https://{service-id}.microcms.io/apis/{endpoint}/{id}
```

## 変更内容

- 単発のコンテンツ作成・更新・部分更新レスポンスに `adminUrl` を追加
- コンテンツステータス変更、作成者変更、公開予約更新レスポンスに `adminUrl` を追加
- 削除済みコンテンツは管理画面でアクセスできなくなるため、削除ツールは対象外
- 複数一括登録系ツールは対象外

## 確認

- `pnpm build`
- `pnpm check`

## 参考（クライアントからツールを利用したケース）

クライアントの処理次第ではあるので、再現性はないものの、以下のように利用されることを確認。

<img width="1290" height="582" alt="CleanShot 2026-07-01 at 9  06 12@2x" src="https://github.com/user-attachments/assets/1cf3bb50-8789-495c-b82d-638339bb77e6" />