### PR TITLE
外部URLからのメディアアップロードが常に400になる不具合を修正

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -195,10 +195,10 @@ export const microCMSClient = {
 export const microCMSManagementClient = {
   uploadMedia: (
     params:
-      | { data: File | Blob }
+      | { data: File | Blob; name?: string }
       | {
-          url: string;
-          fileName?: string;
+          data: string | URL;
+          name?: string;
           customRequestHeaders?: Record<string, string>;
         }
   ) => {
@@ -671,8 +671,8 @@ export async function uploadMedia(
   params:
     | { data: File | Blob; name?: string }
     | {
-        url: string;
-        fileName?: string;
+        data: string | URL;
+        name?: string;
         customRequestHeaders?: Record<string, string>;
       },
   serviceId?: string

--- a/src/tools/upload-media.ts
+++ b/src/tools/upload-media.ts
@@ -46,12 +46,13 @@ export async function handleUploadMedia(
 
   try {
     // Method 1: Upload from external URL
-    // Note: SDK types may not include 'url' property, but API supports it
+    // The SDK's uploadMedia reads the `data` field (Blob | ReadableStream |
+    // string | URL). Passing `{ url }` leaves `data` undefined, so the SDK
+    // sends an empty file and microCMS returns 400.
     if (externalUrl) {
-      const result = await clients.managementClient.uploadMedia(
-        // biome-ignore lint/suspicious/noExplicitAny: SDK type limitation
-        { url: externalUrl } as any
-      );
+      const result = await clients.managementClient.uploadMedia({
+        data: new URL(externalUrl),
+      });
       return result;
     }
 


### PR DESCRIPTION
## 概要

`microcms_upload_media` の `externalUrl`（外部URLからのアップロード）が、**常に** 400 エラーになる不具合を修正します。

## 原因

`microcms-js-sdk` v3 の `uploadMedia` は引数の **`data`** フィールド（`Blob | ReadableStream | string | URL`）を読みます。しかし実装では外部URL経路で `{ url: externalUrl }` を渡していました。

```ts
// Before
const result = await clients.managementClient.uploadMedia(
  { url: externalUrl } as any
);
```

このため SDK 内では `data === undefined` となり、どの分岐にも入らず `FormData` に `file` がセットされないまま POST され、microCMS が 400 を返していました（`as any` キャストのため型エラーでも検知できず）。「Unsplash 以外のURLでも同じ 400」なのは、URL が SDK まで届いていなかったためです。

## 修正内容

- `src/tools/upload-media.ts`: 外部URLを `data: new URL(externalUrl)` として渡すよう修正
- `src/client.ts`: `uploadMedia` ラッパーの型シグネチャを SDK に合わせて `data` / `name` ベースに統一

## 動作確認

- [ ] 外部URLからのメディアアップロードが成功すること

> 注: 既存の `src/transport/http.ts` のビルドエラー（`@hono/mcp` の `bearerAuth`）は本PRとは無関係な依存関係由来の既存問題です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)