### PR TITLE
chore: bump version to 0.11.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "microcms-mcp-server",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "microCMS MCP Bundle - microCMSのコンテンツAPIやマネジメントAPIを利用し、LLMからコンテンツ管理ができるMCP Bundle",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
## 概要

`v0.11.0` タグ作成時に `package.json` が `0.10.0` のままだったため、npm publish が `0.10.0` の再公開を試みて失敗しました。バージョンを `0.11.0` に上げます。

マージ後、タグ `v0.11.0` を貼り直して publish を再実行します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)